### PR TITLE
Add configure flags to generated PKGBUILD

### DIFF
--- a/Distribution/ArchLinux/CabalTranslation.hs
+++ b/Distribution/ArchLinux/CabalTranslation.hs
@@ -37,20 +37,19 @@ import Debug.Trace
 --
 -- | Configure package for system
 --
-preprocessCabal :: GenericPackageDescription -> SystemProvides -> Maybe PackageDescription
-preprocessCabal cabalsrc systemContext =
+preprocessCabal :: GenericPackageDescription -> FlagAssignment -> SystemProvides -> Maybe (PackageDescription, FlagAssignment)
+preprocessCabal cabalsrc flags systemContext =
      case finalizePackageDescription
-        []
+        flags
         (const True) -- could check against prefered pkgs....
         (Platform X86_64 buildOS) -- linux/x86_64
         (CompilerId GHC (Version [6,12,3] []))
-
         -- now constrain it to solve in the context of a modern ghc only
         (corePackages systemContext ++ platformPackages systemContext)
         cabalsrc
      of
         Left deps     -> trace ("Unresolved dependencies: " ++show deps) Nothing
-        Right (pkg,_) -> Just pkg { buildDepends = removeCoreFrom (buildDepends pkg) systemContext }
+        Right (pkg, fs) -> Just (pkg { buildDepends = removeCoreFrom (buildDepends pkg) systemContext }, fs)
 
 -- attempt to filter out core packages we've already satisified
 -- not actually correct, since it doesn't take any version

--- a/Distribution/ArchLinux/HackageTranslation.hs
+++ b/Distribution/ArchLinux/HackageTranslation.hs
@@ -76,12 +76,12 @@ getSpecifiedCabals list packages = filter wasSpecified packages
 --
 getVersionConflicts :: [GenericPackageDescription] -> SystemProvides -> [(PackageDescription, Dependency)]
 getVersionConflicts packages sysProvides = concat $ map conflicts cabals
-  where cabals = mapMaybe (\p -> preprocessCabal p sysProvides) packages
-        versions = M.fromList $ map (\p -> (pkgName $ packageId p, pkgVersion $ packageId p)) cabals
+  where cabals = mapMaybe (\ p -> preprocessCabal p [] sysProvides) packages
+        versions = M.fromList $ map (\ (p, _) -> (pkgName $ packageId p, pkgVersion $ packageId p)) cabals
         issatisfied (Dependency pkg range) = case M.lookup pkg versions of
                                                  Nothing -> True
                                                  Just v -> v `withinRange` range
-        conflicts p = map (\d -> (p,d)) $ filter (not . issatisfied) (buildDepends p)
+        conflicts (p, _) = map (\d -> (p,d)) $ filter (not . issatisfied) (buildDepends p)
 
 --
 -- | Returns the latest versions

--- a/Distribution/ArchLinux/PkgBuild.hs
+++ b/Distribution/ArchLinux/PkgBuild.hs
@@ -262,6 +262,7 @@ data AnnotatedPkgBuild =
         {pkgBuiltWith :: Maybe Version   -- ^ version of cabal2arch used, if any
         ,pkgHeader    :: String          -- ^ header strings
         ,hkgName      :: String          -- ^ package name on Hackage
+        ,cblFlags     :: String          -- ^ flags to be passed to configure action
         ,pkgBody      :: PkgBuild }      -- ^ contents of pkgbuild file
     deriving (Eq, Show)
 
@@ -271,6 +272,7 @@ emptyPkg = AnnotatedPkgBuild
     { pkgBuiltWith = Nothing
     , pkgHeader    = []
     , hkgName      = []
+    , cblFlags     = []
     , pkgBody      = emptyPkgBuild { arch_options = ArchList []
                                 , arch_makedepends = ArchList []
                                 }
@@ -347,6 +349,9 @@ readPackage st = do
             let s = drop 9 h
             readPackage st { hkgName = s }
 
+      | "_cblflags=" `isPrefixOf` cs -> do
+            h <- line cs
+            readPackage st { cblFlags = drop 10 h }
       | "pkgname="  `isPrefixOf` cs -> do
             h <- line cs
             let s = drop 8 h
@@ -524,9 +529,11 @@ instance Text AnnotatedPkgBuild where
     pkgBuiltWith = ver,
     pkgHeader = header,
     hkgName = hkg,
+    cblFlags = flags,
     pkgBody = pkg
   } = vcat [ if null header then empty else text header
            , text "_hkgname" <=> text hkg
+           , text "_cblflags" <=> char '"' <> text flags <> char '"'
            , disp pkg ]
   parse = undefined
 

--- a/archlinux.cabal
+++ b/archlinux.cabal
@@ -1,5 +1,5 @@
 name:           archlinux
-version:        0.3.6
+version:        0.4
 license:        BSD3
 license-file:   LICENSE
 author:         Don Stewart <dons@galois.com>


### PR DESCRIPTION
These changes add a new variable to the generated PKGBUILD, `_cblflags`, populates it with the flag settings coming out of the call to`finalizePackageDescription`, the variable is then passed in at the configure step of the build process.

It's also possible to pass flags to `finalizePackageDescription`.

There's a corresponding change to `cabal2arch` in order to make it work with the modified API: archhaskell/cabal2arch#26

I thought this would warrant a pull request since it modifies the output.
