### PR TITLE
This is a follow-up to: http://www.haskell.org/pipermail/arch-haskell/2011-April/001538.html

### DIFF
--- a/Distribution/ArchLinux/CabalTranslation.hs
+++ b/Distribution/ArchLinux/CabalTranslation.hs
@@ -205,7 +205,7 @@ stubPackageLibrary _ = emptyPkgBuild {
           "http://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz"
     , arch_build =
         [ "cd ${srcdir}/${_hkgname}-${pkgver}"
-        , "runhaskell Setup configure -O --enable-split-objs --enable-shared \\"
+        , "runhaskell Setup configure -O $([[ $PKGBUILD_HASKELL_ENABLE_PROFILING == 1 ]] && echo \"-p\") --enable-split-objs --enable-shared \\"
         , "   --prefix=/usr --docdir=/usr/share/doc/${pkgname} --libsubdir=\\$compiler/site-local/\\$pkgid"
         , "runhaskell Setup build"
         , "runhaskell Setup haddock"


### PR DESCRIPTION
The problem:

Some Arch Haskell developers rely on profiling their
programs, which in turn rely on certain Haskell AUR packages.
Previously, these packages did not have profiling enabled in their
PKGBUILDs, which meant that those who wanted profiling had to rebuild
all packages in the dependency chain that did not have profiling
enabled.

The solution:

This one-liner simply adds in a Bash conditional statement into the
default PKGBUILD for haskell library programs. The statement depends on
the new $PKGBUILD_HASKELL_ENABLE_PROFILING variable having a value "1".
E.g., "export PKGBUILD_HASKELL_ENABLE_PROFILING=1". An Arch Haskell user
can now export this variable in his ~/.bashrc or somewhere else, which
will trigger the conditional statement to enable profiling.

This way, only those users who want profiling will get it, and it will
not affect anyone who does not care about profiling.
