### PR TITLE
Fixes for ghc 7.4

### DIFF
--- a/Distribution/ArchLinux/PkgBuild.hs
+++ b/Distribution/ArchLinux/PkgBuild.hs
@@ -28,7 +28,7 @@ import Distribution.License
 
 import Text.PrettyPrint
 import Data.List
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 import Debug.Trace
 
 import Control.Monad

--- a/Distribution/ArchLinux/PkgBuild.hs
+++ b/Distribution/ArchLinux/PkgBuild.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TypeSynonymInstances       #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleInstances #-}
 -- |
 -- Module    : Distribution.ArchLinux.PkgBuild
 -- Copyright : (c) Don Stewart, 2008-2010


### PR DESCRIPTION
This just doesn't work under ghc 7.4. The <> operator is defined twice in one scope due to Imports and ghc complains about instance-ing a String as an instance of the Text class in the absence of the FlexibleInstances. There's probably a better way to handle the latter than my patch, but I'm not sure what it would entail.
