### PR TITLE
Bump GHC version to 7.6.3

### DIFF
--- a/Distribution/ArchLinux/CabalTranslation.hs
+++ b/Distribution/ArchLinux/CabalTranslation.hs
@@ -43,7 +43,7 @@ preprocessCabal cabalsrc systemContext =
         []
         (const True) -- could check against prefered pkgs....
         (Platform X86_64 buildOS) -- linux/x86_64
-        (CompilerId GHC (Version [7,0,3] []))
+        (CompilerId GHC (Version [7,6,3] []))
 
         -- now constrain it to solve in the context of a modern ghc only
         (corePackages systemContext ++ platformPackages systemContext)

--- a/Distribution/ArchLinux/PkgBuild.hs
+++ b/Distribution/ArchLinux/PkgBuild.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TypeSynonymInstances       #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleInstances #-}
 -- |
 -- Module    : Distribution.ArchLinux.PkgBuild
 -- Copyright : (c) Don Stewart, 2008-2010
@@ -28,7 +29,7 @@ import Distribution.License
 
 import Text.PrettyPrint
 import Data.List
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 import Debug.Trace
 
 import Control.Monad

--- a/archlinux.cabal
+++ b/archlinux.cabal
@@ -1,5 +1,5 @@
 name:           archlinux
-version:        1.3
+version:        1.4
 license:        BSD3
 license-file:   LICENSE
 author:         Don Stewart <dons@galois.com>,


### PR DESCRIPTION
Version 1.3 doesn't build anymore with GHC 7.6.3. This is a problem when using `archlinux` or `archlinux-web` as dependency in cabal.

It would be nice to also push this version to Hackage to simplify the installation with `cabal install` of package having this dependency.
